### PR TITLE
Fix typo, and note BoundObjectRef isn't always checked

### DIFF
--- a/packages/inferno-router/__tests__/Switch.spec.jsx
+++ b/packages/inferno-router/__tests__/Switch.spec.jsx
@@ -305,6 +305,50 @@ describe('Switch (jsx)', () => {
       );
     }).toThrowError(/You should not use <Switch> outside a <Router>/);
   });
+
+  it('matches and renders array children correctly', () => {
+    const node = document.createElement('div');
+
+    render(
+      <MemoryRouter initialEntries={['/bubblegum']}>
+        <Switch>
+          <Route path="/ice-cream" render={() => <div>beb</div>} />
+          {[<Route path="/bubblegum" render={() => <div>bub</div>} />]}
+          <Route path="/cupcakes" render={() => <div>cup</div>} />
+        </Switch>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).not.toContain('beb');
+    expect(node.innerHTML).toContain('bub');
+    expect(node.innerHTML).not.toContain('cup');
+  });
+
+  it('matches and renders children in nested arrays correctly', () => {
+    const node = document.createElement('div');
+
+    render(
+      <MemoryRouter initialEntries={['/bubblegum']}>
+        <Switch>
+          {[[<Route path="/ice-cream" render={() => <div>beb</div>} />]]}
+          {[
+            <Route path="/something" render={() => <div>bab</div>} />,
+            <Route path="/something-else" render={() => <div>bib</div>} />,
+            [<Route path="/bubblegum" render={() => <div>bub</div>} />]
+          ]}
+          <Route path="/cupcakes" render={() => <div>cup</div>} />
+        </Switch>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain('bub');
+    expect(node.innerHTML).not.toContain('beb');
+    expect(node.innerHTML).not.toContain('bab');
+    expect(node.innerHTML).not.toContain('bib');
+    expect(node.innerHTML).not.toContain('cup');
+  });
 });
 
 describe('A <Switch location>', () => {


### PR DESCRIPTION
…rectly (#1441)

Switch rendering previously correctly treated multiple children, however it failed to process nested arrays, such as the result of an Array.prototype.map(...) call next to a regular child component

 *Before* submitting a PR please:
 - Include tests for the functionality you are adding! See CONTRIBUTING.md for details how to run tests.
 - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
 - Run `npm run build` and check that the build succeeds.
 - Ensure that the PR hasn't been submitted before.

---

## PR Template

**Objective**

This PR...

**Closes Issue**

It closes Issue #...
